### PR TITLE
Feature/refactor blocking methods to use coroutines

### DIFF
--- a/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/TasksLocalDataSourceTest.kt
+++ b/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/TasksLocalDataSourceTest.kt
@@ -46,7 +46,7 @@ import org.junit.runner.RunWith
                 InstrumentationRegistry.getTargetContext())
     }
 
-    @After fun cleanUp() {
+    @After fun cleanUp() = runBlocking<Unit> {
         localDataSource.deleteAllTasks()
     }
 

--- a/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
+++ b/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
@@ -30,6 +30,7 @@ import android.support.test.runner.AndroidJUnit4
 import android.view.View
 import android.widget.ListView
 import com.example.android.architecture.blueprints.todoapp.*
+import kotlinx.coroutines.experimental.runBlocking
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.Matchers.allOf
@@ -59,7 +60,7 @@ import org.junit.runner.RunWith
     @Rule @JvmField var tasksActivityTestRule =
             ActivityTestRule<TasksActivity>(TasksActivity::class.java)
 
-    @Before fun resetState() {
+    @Before fun resetState() = runBlocking<Unit> {
         ViewModelFactory.destroyInstance()
         Injection.provideTasksRepository(InstrumentationRegistry.getTargetContext())
                 .deleteAllTasks()

--- a/todoapp/app/src/androidTestMock/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsScreenTest.kt
+++ b/todoapp/app/src/androidTestMock/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsScreenTest.kt
@@ -31,6 +31,7 @@ import com.example.android.architecture.blueprints.todoapp.ViewModelFactory
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.taskdetail.TaskDetailActivity
 import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingResource
+import kotlinx.coroutines.experimental.runBlocking
 import org.hamcrest.Matchers.containsString
 import org.junit.After
 import org.junit.Before
@@ -64,7 +65,7 @@ import org.junit.runner.RunWith
      * the service API. This is a great way to make your tests more reliable and faster at the same
      * time, since they are isolated from any outside dependencies.
      */
-    @Before fun intentWithStubbedTaskId() {
+    @Before fun intentWithStubbedTaskId() = runBlocking<Unit> {
         ViewModelFactory.destroyInstance()
         // Given some tasks
         val tasksRepository =

--- a/todoapp/app/src/androidTestMock/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailScreenTest.kt
+++ b/todoapp/app/src/androidTestMock/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailScreenTest.kt
@@ -18,14 +18,10 @@ package com.example.android.architecture.blueprints.todoapp.taskdetail
 import android.app.Activity
 import android.content.Intent
 import android.support.test.InstrumentationRegistry
-import android.support.test.espresso.Espresso
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.IdlingRegistry
 import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers.isChecked
-import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
-import android.support.test.espresso.matcher.ViewMatchers.withId
-import android.support.test.espresso.matcher.ViewMatchers.withText
+import android.support.test.espresso.matcher.ViewMatchers.*
 import android.support.test.filters.LargeTest
 import android.support.test.rule.ActivityTestRule
 import android.support.test.runner.AndroidJUnit4
@@ -36,6 +32,7 @@ import com.example.android.architecture.blueprints.todoapp.data.FakeTasksRemoteD
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.rotateOrientation
 import com.example.android.architecture.blueprints.todoapp.util.EspressoIdlingResource
+import kotlinx.coroutines.experimental.runBlocking
 import org.hamcrest.core.IsNot.not
 import org.junit.After
 import org.junit.Before
@@ -66,11 +63,11 @@ import org.junit.runner.RunWith
     @get:Rule var taskDetailActivityTestRule = ActivityTestRule(TaskDetailActivity::class.java,
             /* Initial touch mode  */ true, /* Lazily launch activity */ false)
 
-    private fun loadActiveTask() {
+    private suspend fun loadActiveTask() {
         startActivityWithWithStubbedTask(ACTIVE_TASK)
     }
 
-    private fun loadCompletedTask() {
+    private suspend fun loadCompletedTask() {
         startActivityWithWithStubbedTask(COMPLETED_TASK)
     }
 
@@ -84,7 +81,7 @@ import org.junit.runner.RunWith
      * the service API. This is a great way to make your tests more reliable and faster at the same
      * time, since they are isolated from any outside dependencies.
      */
-    private fun startActivityWithWithStubbedTask(task: Task) {
+    private suspend fun startActivityWithWithStubbedTask(task: Task) {
         // Add a task stub to the fake service api layer.
         Injection.provideTasksRepository(InstrumentationRegistry.getTargetContext()).apply {
             deleteAllTasks()
@@ -108,7 +105,7 @@ import org.junit.runner.RunWith
         IdlingRegistry.getInstance().register(EspressoIdlingResource.countingIdlingResource)
     }
 
-    @Test fun activeTaskDetails_DisplayedInUi() {
+    @Test fun activeTaskDetails_DisplayedInUi() = runBlocking<Unit> {
         loadActiveTask()
 
         // Check that the task title and description are displayed
@@ -117,7 +114,7 @@ import org.junit.runner.RunWith
         onView(withId(R.id.task_detail_complete)).check(matches(not<View>(isChecked())))
     }
 
-    @Test fun completedTaskDetails_DisplayedInUi() {
+    @Test fun completedTaskDetails_DisplayedInUi() = runBlocking<Unit> {
         loadCompletedTask()
 
         // Check that the task title and description are displayed
@@ -126,7 +123,7 @@ import org.junit.runner.RunWith
         onView(withId(R.id.task_detail_complete)).check(matches(isChecked()))
     }
 
-    @Test fun orientationChange_menuAndTaskPersist() {
+    @Test fun orientationChange_menuAndTaskPersist() = runBlocking<Unit> {
         loadActiveTask()
 
         // Check delete menu item is displayed and is unique

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
@@ -85,11 +85,11 @@ class AddEditTaskViewModel(
     }
 
     // Called when clicking on fab.
-    fun saveTask() {
+    fun saveTask() = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         val task = Task(title.get(), description.get())
         if (task.isEmpty) {
             showSnackbarMessage(R.string.empty_task_message)
-            return
+            return@launch
         }
         if (isNewTask) {
             createTask(task)
@@ -102,12 +102,12 @@ class AddEditTaskViewModel(
     }
 
 
-    private fun createTask(newTask: Task) {
+    private suspend fun createTask(newTask: Task) {
         tasksRepository.saveTask(newTask)
         taskUpdatedEvent.call()
     }
 
-    private fun updateTask(task: Task) {
+    private suspend fun updateTask(task: Task) {
         if (isNewTask) {
             throw RuntimeException("updateTask() was called but task is new.")
         }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
@@ -55,31 +55,29 @@ class AddEditTaskViewModel(
     private var isDataLoaded = false
     private var taskCompleted = false
 
-    fun start(taskId: String?) {
+    fun start(taskId: String?) = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         if (dataLoading.get()) {
             // Already loading, ignore.
-            return
+            return@launch
         }
-        this.taskId = taskId
+        this@AddEditTaskViewModel.taskId = taskId
         if (isNewTask || isDataLoaded) {
             // No need to populate, it's a new task or it already has data
-            return
+            return@launch
         }
 
         if (taskId != null) {
-            launch(dispatcher, CoroutineStart.UNDISPATCHED) {
-                dataLoading.set(true)
-                val task = tasksRepository.getTask(taskId)
-                dataLoading.set(false)
-                if (task != null) {
-                    title.set(task.title)
-                    description.set(task.description)
-                    taskCompleted = task.isCompleted
-                    isDataLoaded = true
+            dataLoading.set(true)
+            val task = tasksRepository.getTask(taskId)
+            dataLoading.set(false)
+            if (task != null) {
+                title.set(task.title)
+                description.set(task.description)
+                taskCompleted = task.isCompleted
+                isDataLoaded = true
 
-                    // Note that there's no need to notify that the values changed because we're using
-                    // ObservableFields.
-                }
+                // Note that there's no need to notify that the values changed because we're using
+                // ObservableFields.
             }
         }
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
@@ -32,7 +32,7 @@ interface TasksDataSource {
 
     suspend fun getTask(taskId: String): Task?
 
-    fun saveTask(task: Task)
+    suspend fun saveTask(task: Task)
 
     fun completeTask(task: Task)
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
@@ -19,12 +19,6 @@ import com.example.android.architecture.blueprints.todoapp.data.Task
 
 /**
  * Main entry point for accessing tasks data.
- *
- *
- * For simplicity, only getTasks() and getTask() have callbacks. Consider adding callbacks to other
- * methods to inform the user of network/database errors or successful operations.
- * For example, when a new task is created, it's synchronously stored in cache but usually every
- * operation on database or network should be executed in a different thread.
  */
 interface TasksDataSource {
 
@@ -48,5 +42,5 @@ interface TasksDataSource {
 
     suspend fun deleteAllTasks()
 
-    fun deleteTask(taskId: String)
+    suspend fun deleteTask(taskId: String)
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
@@ -34,9 +34,9 @@ interface TasksDataSource {
 
     suspend fun saveTask(task: Task)
 
-    fun completeTask(task: Task)
+    suspend fun completeTask(task: Task)
 
-    fun completeTask(taskId: String)
+    suspend fun completeTask(taskId: String)
 
     fun activateTask(task: Task)
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
@@ -46,7 +46,7 @@ interface TasksDataSource {
 
     fun refreshTasks()
 
-    fun deleteAllTasks()
+    suspend fun deleteAllTasks()
 
     fun deleteTask(taskId: String)
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
@@ -38,9 +38,9 @@ interface TasksDataSource {
 
     suspend fun completeTask(taskId: String)
 
-    fun activateTask(task: Task)
+    suspend fun activateTask(task: Task)
 
-    fun activateTask(taskId: String)
+    suspend fun activateTask(taskId: String)
 
     fun clearCompletedTasks()
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
@@ -42,7 +42,7 @@ interface TasksDataSource {
 
     suspend fun activateTask(taskId: String)
 
-    fun clearCompletedTasks()
+    suspend fun clearCompletedTasks()
 
     fun refreshTasks()
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -94,7 +94,7 @@ class TasksRepository(
         }
     }
 
-    override fun activateTask(task: Task) {
+    override suspend fun activateTask(task: Task) {
         // Do in memory cache update to keep the app UI up to date
         cache(task).let {
             it.isCompleted = false
@@ -103,7 +103,7 @@ class TasksRepository(
         }
     }
 
-    override fun activateTask(taskId: String) {
+    override suspend fun activateTask(taskId: String) {
         getTaskWithId(taskId)?.let {
             activateTask(it)
         }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -156,7 +156,7 @@ class TasksRepository(
         cachedTasks.clear()
     }
 
-    override fun deleteTask(taskId: String) {
+    override suspend fun deleteTask(taskId: String) {
         tasksRemoteDataSource.deleteTask(taskId)
         tasksLocalDataSource.deleteTask(taskId)
         cachedTasks.remove(taskId)

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -150,7 +150,7 @@ class TasksRepository(
         cacheIsDirty = true
     }
 
-    override fun deleteAllTasks() {
+    override suspend fun deleteAllTasks() {
         tasksRemoteDataSource.deleteAllTasks()
         tasksLocalDataSource.deleteAllTasks()
         cachedTasks.clear()

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -79,7 +79,7 @@ class TasksRepository(
         }
     }
 
-    override fun completeTask(task: Task) {
+    override suspend fun completeTask(task: Task) {
         // Do in memory cache update to keep the app UI up to date
         cache(task).let {
             it.isCompleted = true
@@ -88,7 +88,7 @@ class TasksRepository(
         }
     }
 
-    override fun completeTask(taskId: String) {
+    override suspend fun completeTask(taskId: String) {
         getTaskWithId(taskId)?.let {
             completeTask(it)
         }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -16,7 +16,6 @@
 package com.example.android.architecture.blueprints.todoapp.data.source
 
 import com.example.android.architecture.blueprints.todoapp.data.Task
-import java.util.*
 
 /**
  * Concrete implementation to load tasks from the data sources into a cache.
@@ -34,7 +33,7 @@ class TasksRepository(
     /**
      * This variable has public visibility so it can be accessed from tests.
      */
-    var cachedTasks: LinkedHashMap<String, Task> = LinkedHashMap()
+    var cachedTasks = mutableMapOf<String, Task>()
 
     /**
      * Marks the cache as invalid, to force an update the next time data is requested. This variable
@@ -109,13 +108,13 @@ class TasksRepository(
         }
     }
 
-    override fun clearCompletedTasks() {
+    override suspend fun clearCompletedTasks() {
         tasksRemoteDataSource.clearCompletedTasks()
         tasksLocalDataSource.clearCompletedTasks()
 
         cachedTasks = cachedTasks.filterValues {
             !it.isCompleted
-        } as LinkedHashMap<String, Task>
+        }.toMutableMap()
     }
 
     /**

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -71,7 +71,7 @@ class TasksRepository(
         }
     }
 
-    override fun saveTask(task: Task) {
+    override suspend fun saveTask(task: Task) {
         // Do in memory cache update to keep the app UI up to date
         cache(task).let {
             tasksRemoteDataSource.saveTask(it)
@@ -182,7 +182,7 @@ class TasksRepository(
         cacheIsDirty = false
     }
 
-    private fun refreshLocalDataSource(tasks: List<Task>) {
+    private suspend fun refreshLocalDataSource(tasks: List<Task>) {
         tasksLocalDataSource.deleteAllTasks()
         for (task in tasks) {
             tasksLocalDataSource.saveTask(task)

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
@@ -157,7 +157,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         // tasks from all the available data sources.
     }
 
-    override fun deleteAllTasks() {
+    override suspend fun deleteAllTasks() = run(DefaultDispatcher) {
         with(dbHelper.writableDatabase) {
             delete(TABLE_NAME, null, null)
             close()

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
@@ -25,7 +25,7 @@ import com.example.android.architecture.blueprints.todoapp.data.source.local.Tas
 import com.example.android.architecture.blueprints.todoapp.data.source.local.TasksPersistenceContract.TaskEntry.COLUMN_NAME_ENTRY_ID
 import com.example.android.architecture.blueprints.todoapp.data.source.local.TasksPersistenceContract.TaskEntry.COLUMN_NAME_TITLE
 import com.example.android.architecture.blueprints.todoapp.data.source.local.TasksPersistenceContract.TaskEntry.TABLE_NAME
-import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.DefaultDispatcher
 import kotlinx.coroutines.experimental.run
 import kotlinx.coroutines.experimental.runBlocking
 
@@ -40,7 +40,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
      * Note: [LoadTasksCallback.onDataNotAvailable] is fired if the database doesn't exist
      * or the table is empty.
      */
-    override suspend fun getTasks(): List<Task>? = run(CommonPool) {
+    override suspend fun getTasks(): List<Task>? = run(DefaultDispatcher) {
         dbHelper.readableDatabase.use { db ->
 
             val projection = arrayOf(COLUMN_NAME_ENTRY_ID, COLUMN_NAME_TITLE,
@@ -73,7 +73,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
     /**
      * Note: the null is returned if the [Task] isn't found.
      */
-     override suspend fun getTask(taskId: String): Task? = run(CommonPool) {
+     override suspend fun getTask(taskId: String): Task? = run(DefaultDispatcher) {
         dbHelper.readableDatabase.use { db ->
 
             val projection = arrayOf(COLUMN_NAME_ENTRY_ID, COLUMN_NAME_TITLE,
@@ -99,7 +99,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         }
     }
 
-    override suspend fun saveTask(task: Task) = run(CommonPool) {
+    override suspend fun saveTask(task: Task) = run(DefaultDispatcher) {
         val values = ContentValues().apply {
             put(COLUMN_NAME_ENTRY_ID, task.id)
             put(COLUMN_NAME_TITLE, task.title)
@@ -112,7 +112,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         }
     }
 
-    override fun completeTask(task: Task) {
+    override suspend fun completeTask(task: Task) = run(DefaultDispatcher) {
         val values = ContentValues().apply {
             put(COLUMN_NAME_COMPLETED, true)
         }
@@ -122,7 +122,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         }
     }
 
-    override fun completeTask(taskId: String) {
+    override suspend fun completeTask(taskId: String) {
         // Not required for the local data source because the {@link TasksRepository} handles
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
@@ -99,7 +99,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         }
     }
 
-    override fun saveTask(task: Task) {
+    override suspend fun saveTask(task: Task) = run(CommonPool) {
         val values = ContentValues().apply {
             put(COLUMN_NAME_ENTRY_ID, task.id)
             put(COLUMN_NAME_TITLE, task.title)

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
@@ -127,7 +127,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }
 
-    override fun activateTask(task: Task) {
+    override suspend fun activateTask(task: Task) = run(DefaultDispatcher) {
         val values = ContentValues().apply {
             put(COLUMN_NAME_COMPLETED, false)
         }
@@ -138,7 +138,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         }
     }
 
-    override fun activateTask(taskId: String) {
+    override suspend fun activateTask(taskId: String) {
         // Not required for the local data source because the {@link TasksRepository} handles
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
@@ -164,7 +164,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         }
     }
 
-    override fun deleteTask(taskId: String) {
+    override suspend fun deleteTask(taskId: String) = run(DefaultDispatcher) {
         val selection = "$COLUMN_NAME_ENTRY_ID LIKE ?"
         val selectionArgs = arrayOf(taskId)
         with(dbHelper.writableDatabase) {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
@@ -143,7 +143,7 @@ class TasksLocalDataSource private constructor(context: Context) : TasksDataSour
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }
 
-    override fun clearCompletedTasks() {
+    override suspend fun clearCompletedTasks() = run(DefaultDispatcher) {
         val selection = "$COLUMN_NAME_COMPLETED LIKE ?"
         val selectionArgs = arrayOf("1")
         with(dbHelper.writableDatabase) {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -76,12 +76,12 @@ object TasksRemoteDataSource : TasksDataSource {
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }
 
-    override fun activateTask(task: Task) {
+    override suspend fun activateTask(task: Task) {
         val activeTask = Task(task.title, task.description, task.id)
-        TASKS_SERVICE_DATA.put(task.id, activeTask)
+        TASKS_SERVICE_DATA[task.id] = activeTask
     }
 
-    override fun activateTask(taskId: String) {
+    override suspend fun activateTask(taskId: String) {
         // Not required for the remote data source because the {@link TasksRepository} handles
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -100,7 +100,7 @@ object TasksRemoteDataSource : TasksDataSource {
         TASKS_SERVICE_DATA.clear()
     }
 
-    override fun deleteTask(taskId: String) {
+    override suspend fun deleteTask(taskId: String) {
         TASKS_SERVICE_DATA.remove(taskId)
     }
 }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -60,8 +60,8 @@ object TasksRemoteDataSource : TasksDataSource {
         return TASKS_SERVICE_DATA[taskId]
     }
 
-    override fun saveTask(task: Task) {
-        TASKS_SERVICE_DATA.put(task.id, task)
+    override suspend fun saveTask(task: Task) {
+        TASKS_SERVICE_DATA[task.id] = task
     }
 
     override fun completeTask(task: Task) {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -64,14 +64,14 @@ object TasksRemoteDataSource : TasksDataSource {
         TASKS_SERVICE_DATA[task.id] = task
     }
 
-    override fun completeTask(task: Task) {
+    override suspend fun completeTask(task: Task) {
         val completedTask = Task(task.title, task.description, task.id).apply {
             isCompleted = true
         }
-        TASKS_SERVICE_DATA.put(task.id, completedTask)
+        TASKS_SERVICE_DATA[task.id] = completedTask
     }
 
-    override fun completeTask(taskId: String) {
+    override suspend fun completeTask(taskId: String) {
         // Not required for the remote data source because the {@link TasksRepository} handles
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -26,20 +26,19 @@ object TasksRemoteDataSource : TasksDataSource {
 
     private const val SERVICE_LATENCY_IN_MILLIS = 5000L
 
-    private var TASKS_SERVICE_DATA = LinkedHashMap<String, Task>(2)
+    private var TASKS_SERVICE_DATA: MutableMap<String, Task>
 
     init {
-        addTask("Build tower in Pisa", "Ground looks good, no foundation work required.")
-        addTask("Finish bridge in Tacoma", "Found awesome girders at half the cost!")
-    }
+        val initialTasks = listOf<Task>(
+                Task("Build tower in Pisa", "Ground looks good, no foundation work required."),
+                Task("Finish bridge in Tacoma", "Found awesome girders at half the cost!")
+        )
 
-    private fun addTask(title: String, description: String) {
-        val newTask = Task(title, description)
-        TASKS_SERVICE_DATA.put(newTask.id, newTask)
+        TASKS_SERVICE_DATA = initialTasks.associateBy { task -> task.id }.toMutableMap()
     }
 
     /**
-     * Note: [null] is never returned. In a real remote data
+     * Note: null is never returned. In a real remote data
      * source implementation, this would be fired if the server can't be contacted or the server
      * returns an error.
      */
@@ -50,7 +49,7 @@ object TasksRemoteDataSource : TasksDataSource {
     }
 
     /**
-     * Note: [null] is never returned. In a real remote data
+     * Note: null is never returned. In a real remote data
      * source implementation, this would be fired if the server can't be contacted or the server
      * returns an error.
      */
@@ -86,10 +85,10 @@ object TasksRemoteDataSource : TasksDataSource {
         // converting from a {@code taskId} to a {@link task} using its cached data.
     }
 
-    override fun clearCompletedTasks() {
+    override suspend fun clearCompletedTasks() {
         TASKS_SERVICE_DATA = TASKS_SERVICE_DATA.filterValues {
             !it.isCompleted
-        } as LinkedHashMap<String, Task>
+        }.toMutableMap()
     }
 
     override fun refreshTasks() {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -96,7 +96,7 @@ object TasksRemoteDataSource : TasksDataSource {
         // tasks from all the available data sources.
     }
 
-    override fun deleteAllTasks() {
+    override suspend fun deleteAllTasks() {
         TASKS_SERVICE_DATA.clear()
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -62,11 +62,11 @@ class TaskDetailViewModel(
         editTaskCommand.call()
     }
 
-    fun setCompleted(completed: Boolean) {
+    fun setCompleted(completed: Boolean) = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         if (isDataLoading) {
-            return
+            return@launch
         }
-        val task = this.task.get().apply {
+        val task = this@TaskDetailViewModel.task.get().apply {
             isCompleted = completed
         }
         if (completed) {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -51,7 +51,7 @@ class TaskDetailViewModel(
     val isDataAvailable
         get() = task.get() != null
 
-    fun deleteTask() {
+    fun deleteTask() = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         task.get()?.let {
             tasksRepository.deleteTask(it.id)
             deleteTaskCommand.call()

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -78,14 +78,12 @@ class TaskDetailViewModel(
         }
     }
 
-    fun start(taskId: String?) {
+    fun start(taskId: String?) = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         if (taskId != null) {
-            launch(dispatcher, CoroutineStart.UNDISPATCHED) {
-                isDataLoading = true
-                val task = tasksRepository.getTask(taskId)
-                isDataLoading = false
-                setTask(task)
-            }
+            isDataLoading = true
+            val task = tasksRepository.getTask(taskId)
+            isDataLoading = false
+            setTask(task)
         }
     }
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -78,7 +78,7 @@ class TasksViewModel(
         loadTasks(false)
     }
 
-    fun loadTasks(forceUpdate: Boolean) {
+    fun loadTasks(forceUpdate: Boolean) = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         loadTasks(forceUpdate, true)
     }
 
@@ -168,7 +168,7 @@ class TasksViewModel(
      * *
      * @param showLoadingUI Pass in true to display a loading icon in the UI
      */
-    private fun loadTasks(forceUpdate: Boolean, showLoadingUI: Boolean) = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
+    private suspend fun loadTasks(forceUpdate: Boolean, showLoadingUI: Boolean) {
         if (showLoadingUI) {
             dataLoading.set(true)
         }

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -123,7 +123,7 @@ class TasksViewModel(
         loadTasks(false, false)
     }
 
-    fun completeTask(task: Task, completed: Boolean) {
+    fun completeTask(task: Task, completed: Boolean) = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         // Update the entity
         task.isCompleted = completed
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -117,7 +117,7 @@ class TasksViewModel(
         }
     }
 
-    fun clearCompletedTasks() {
+    fun clearCompletedTasks() = launch(dispatcher, CoroutineStart.UNDISPATCHED) {
         tasksRepository.clearCompletedTasks()
         snackbarMessage.value = R.string.completed_tasks_cleared
         loadTasks(false, false)

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
@@ -17,14 +17,13 @@ package com.example.android.architecture.blueprints.todoapp.data
 
 import android.support.annotation.VisibleForTesting
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource
-import java.util.*
 
 /**
  * Implementation of a remote data source with static access to the data for easy testing.
  */
 object FakeTasksRemoteDataSource : TasksDataSource {
 
-    private var TASKS_SERVICE_DATA: LinkedHashMap<String, Task> = LinkedHashMap()
+    private var TASKS_SERVICE_DATA = mutableMapOf<String, Task>()
 
     override suspend fun getTasks(): List<Task>? = TASKS_SERVICE_DATA.values.toList()
 
@@ -53,10 +52,10 @@ object FakeTasksRemoteDataSource : TasksDataSource {
         // Not required for the remote data source.
     }
 
-    override fun clearCompletedTasks() {
+    override suspend fun clearCompletedTasks() {
         TASKS_SERVICE_DATA = TASKS_SERVICE_DATA.filterValues {
             !it.isCompleted
-        } as LinkedHashMap<String, Task>
+        }.toMutableMap()
     }
 
     override fun refreshTasks() {

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
@@ -34,13 +34,13 @@ object FakeTasksRemoteDataSource : TasksDataSource {
         TASKS_SERVICE_DATA[task.id] = task
     }
 
-    override fun completeTask(task: Task) {
+    override suspend fun completeTask(task: Task) {
         val completedTask = Task(task.title, task.description, task.id)
         completedTask.isCompleted = true
         TASKS_SERVICE_DATA.put(task.id, completedTask)
     }
 
-    override fun completeTask(taskId: String) {
+    override suspend fun completeTask(taskId: String) {
         // Not required for the remote data source.
     }
 

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
@@ -30,8 +30,8 @@ object FakeTasksRemoteDataSource : TasksDataSource {
 
     override suspend fun getTask(taskId: String): Task? = TASKS_SERVICE_DATA[taskId]
 
-    override fun saveTask(task: Task) {
-        TASKS_SERVICE_DATA.put(task.id, task)
+    override suspend fun saveTask(task: Task) {
+        TASKS_SERVICE_DATA[task.id] = task
     }
 
     override fun completeTask(task: Task) {

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
@@ -67,7 +67,7 @@ object FakeTasksRemoteDataSource : TasksDataSource {
         TASKS_SERVICE_DATA.remove(taskId)
     }
 
-    override fun deleteAllTasks() {
+    override suspend fun deleteAllTasks() {
         TASKS_SERVICE_DATA.clear()
     }
 

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
@@ -63,7 +63,7 @@ object FakeTasksRemoteDataSource : TasksDataSource {
         // tasks from all the available data sources.
     }
 
-    override fun deleteTask(taskId: String) {
+    override suspend fun deleteTask(taskId: String) {
         TASKS_SERVICE_DATA.remove(taskId)
     }
 

--- a/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
+++ b/todoapp/app/src/mock/java/com/example/android/architecture/blueprints/todoapp/data/FakeTasksRemoteDataSource.kt
@@ -44,12 +44,12 @@ object FakeTasksRemoteDataSource : TasksDataSource {
         // Not required for the remote data source.
     }
 
-    override fun activateTask(task: Task) {
+    override suspend fun activateTask(task: Task) {
         val activeTask = Task(task.title, task.description, task.id)
-        TASKS_SERVICE_DATA.put(task.id, activeTask)
+        TASKS_SERVICE_DATA[task.id] = activeTask
     }
 
-    override fun activateTask(taskId: String) {
+    override suspend fun activateTask(taskId: String) {
         // Not required for the remote data source.
     }
 

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.kt
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModelTest.kt
@@ -54,7 +54,7 @@ class AddEditTaskViewModelTest {
         addEditTaskViewModel = AddEditTaskViewModel(mock<Application>(), tasksRepository, Unconfined)
     }
 
-    @Test fun saveNewTaskToRepository_showsSuccessMessageUi() {
+    @Test fun saveNewTaskToRepository_showsSuccessMessageUi() = runBlocking<Unit> {
         // When the ViewModel is asked to save a task
         with(addEditTaskViewModel) {
             description.set("Some Task Description")

--- a/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepositoryTest.kt
+++ b/todoapp/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepositoryTest.kt
@@ -75,7 +75,7 @@ class TasksRepositoryTest {
         verify<TasksDataSource>(tasksLocalDataSource).getTasks()
     }
 
-    @Test fun saveTask_savesTaskToServiceAPI() {
+    @Test fun saveTask_savesTaskToServiceAPI() = runBlocking<Unit> {
         // Given a stub task with title and description
         val newTask = Task(TASK_TITLE, TASK_DESCRIPTION)
 
@@ -88,7 +88,7 @@ class TasksRepositoryTest {
         assertThat(tasksRepository.cachedTasks.size, `is`(1))
     }
 
-    @Test fun completeTask_completesTaskToServiceAPIUpdatesCache() {
+    @Test fun completeTask_completesTaskToServiceAPIUpdatesCache() = runBlocking<Unit> {
         with(tasksRepository) {
             // Given a stub active task with title and description added in the repository
             val newTask = Task(TASK_TITLE, TASK_DESCRIPTION)
@@ -108,7 +108,7 @@ class TasksRepositoryTest {
         }
     }
 
-    @Test fun completeTaskId_completesTaskToServiceAPIUpdatesCache() {
+    @Test fun completeTaskId_completesTaskToServiceAPIUpdatesCache() = runBlocking<Unit> {
         with(tasksRepository) {
             // Given a stub active task with title and description added in the repository
             Task(TASK_TITLE, TASK_DESCRIPTION).also {
@@ -128,7 +128,7 @@ class TasksRepositoryTest {
         }
     }
 
-    @Test fun activateTask_activatesTaskToServiceAPIUpdatesCache() {
+    @Test fun activateTask_activatesTaskToServiceAPIUpdatesCache() = runBlocking<Unit> {
         // Given a stub completed task with title and description in the repository
         val newTask = Task(TASK_TITLE, TASK_DESCRIPTION).apply { isCompleted = true }
         with(tasksRepository) {
@@ -145,7 +145,7 @@ class TasksRepositoryTest {
         }
     }
 
-    @Test fun activateTaskId_activatesTaskToServiceAPIUpdatesCache() {
+    @Test fun activateTaskId_activatesTaskToServiceAPIUpdatesCache() = runBlocking<Unit> {
         // Given a stub completed task with title and description in the repository
         val newTask = Task(TASK_TITLE, TASK_DESCRIPTION).apply { isCompleted = true }
         with(tasksRepository) {
@@ -172,7 +172,7 @@ class TasksRepositoryTest {
         verify(tasksLocalDataSource).getTask(eq(TASK_TITLE))
     }
 
-    @Test fun deleteCompletedTasks_deleteCompletedTasksToServiceAPIUpdatesCache() {
+    @Test fun deleteCompletedTasks_deleteCompletedTasksToServiceAPIUpdatesCache() = runBlocking<Unit> {
         with(tasksRepository) {
             // Given 2 stub completed tasks and 1 stub active tasks in the repository
             val newTask = Task(TASK_TITLE, TASK_DESCRIPTION).apply { isCompleted = true }
@@ -198,7 +198,7 @@ class TasksRepositoryTest {
         }
     }
 
-    @Test fun deleteAllTasks_deleteTasksToServiceAPIUpdatesCache() {
+    @Test fun deleteAllTasks_deleteTasksToServiceAPIUpdatesCache() = runBlocking<Unit> {
         with(tasksRepository) {
             // Given 2 stub completed tasks and 1 stub active tasks in the repository
             val newTask = Task(TASK_TITLE, TASK_DESCRIPTION).apply { isCompleted = true }
@@ -219,7 +219,7 @@ class TasksRepositoryTest {
         }
     }
 
-    @Test fun deleteTask_deleteTaskToServiceAPIRemovedFromCache() {
+    @Test fun deleteTask_deleteTaskToServiceAPIRemovedFromCache() = runBlocking<Unit> {
         with(tasksRepository) {
             // Given a task in the repository
             val newTask = Task(TASK_TITLE, TASK_DESCRIPTION).apply { isCompleted }


### PR DESCRIPTION
`TasksDataSource` had a bunch of blocking methods and the suggestion in the comments to make them non-blocking. That is trivial with coroutines - just add `suspend` and `run` here and there, much simpler than RxJava.